### PR TITLE
test: adicionar testes unitários para busca linear

### DIFF
--- a/algoritmo_busca/pesquisa_linear/implementacao_each.rb
+++ b/algoritmo_busca/pesquisa_linear/implementacao_each.rb
@@ -1,12 +1,5 @@
 # Linear search (busca linear) - Mais informações readme
 
-# arrays para cada caso
-array = [10, 25, 43, 33, 190, 5]
-array_primeiro = [43, 25, 343, 33, 190, 5]
-array_ultimo = [10, 25, 23, 33, 190, 43]
-array_sem = [10, 25, 56, 33, 190, 5]
-alvo = 43
-
 # busca_linear com .each
 def busca_linear (array, alvo)
   indice = 0
@@ -22,11 +15,3 @@ def busca_linear (array, alvo)
   # Retorna -1 caso o alvo não seja encontrado no array
   return -1
 end
-
-# teste
-resposta = busca_linear(array, alvo)
-resposta2 = busca_linear(array_primeiro, alvo)
-resposta3 = busca_linear(array_ultimo, alvo)
-resposta4 = busca_linear(array_sem, alvo)
-
-puts(resposta, resposta2, resposta3, resposta4)

--- a/algoritmo_busca/pesquisa_linear/implementacao_each_with_index.rb
+++ b/algoritmo_busca/pesquisa_linear/implementacao_each_with_index.rb
@@ -1,24 +1,9 @@
 # Linear search (busca linear) - Mais informações readme
 
-# arrays para cada caso
-array = [10, 25, 43, 33, 190, 5]
-array_primeiro = [43, 25, 343, 33, 190, 5]
-array_ultimo = [10, 25, 23, 33, 190, 43]
-array_sem = [10, 25, 56, 33, 190, 5]
-alvo = 43
-
 # Versão usando .each_with_index (mais idiomática, dispensa variável de índice manual)
-def busca_linear (array, alvo)
+def busca_linear_index (array, alvo)
   array.each_with_index do |valor, indice|
     return indice if valor == alvo
   end
   return -1
 end
-
-# teste
-resposta = busca_linear(array, alvo)
-resposta2 = busca_linear(array_primeiro, alvo)
-resposta3 = busca_linear(array_ultimo, alvo)
-resposta4 = busca_linear(array_sem, alvo)
-
-puts(resposta, resposta2, resposta3, resposta4)

--- a/algoritmo_busca/pesquisa_linear/test_implementacao.rb
+++ b/algoritmo_busca/pesquisa_linear/test_implementacao.rb
@@ -1,0 +1,51 @@
+# Habilitando biblioteca de testes
+require "minitest/autorun"
+
+# Carregar arquivos Ruby que estão no seu projeto, relativamente ao arquivo atual.
+require_relative "implementacao_each"
+require_relative "implementacao_each_with_index"
+
+class TestBuscaLinear < Minitest::Test
+  # Método setup executado antes de cada teste. Define arrays de teste comuns e o alvo
+  def setup
+    @array = [10, 25, 43, 33, 190, 5]
+    @array_primeiro = [43, 25, 343, 33, 190, 5]
+    @array_ultimo = [10, 25, 23, 33, 190, 43]
+    @array_sem = [10, 25, 56, 33, 190, 5]
+    @alvo = 43
+  end
+
+  # Testes da versão com each
+  def test_each 
+    assert_equal 2, busca_linear(@array, @alvo) # elemento no meio
+  end
+  
+  def test_each_inicio 
+    assert_equal 0, busca_linear(@array_primeiro, @alvo) # elemento no inicio
+  end
+
+  def test_each_ultimo 
+    assert_equal 5, busca_linear(@array_ultimo, @alvo) # elemento no final
+  end
+
+  def test_each_inexistente 
+    assert_equal(-1, busca_linear(@array_sem, @alvo)) # elemento inexistente
+  end
+
+  # Testes da versão com each.with.index
+  def test_each_with_index
+    assert_equal 2, busca_linear_index(@array, @alvo) # elemento no meio
+  end
+
+  def test_each_with_index_inicio 
+    assert_equal 0, busca_linear_index(@array_primeiro, @alvo) # elemento no inicio
+  end
+
+  def test_each_with_index_ultimo 
+    assert_equal 5, busca_linear_index(@array_ultimo, @alvo) # elemento no final
+  end
+
+  def test_each_with_index_inexistente 
+    assert_equal(-1, busca_linear_index(@array_sem, @alvo)) # elemento inexistente
+  end
+end


### PR DESCRIPTION
Inclui testes para as duas implementações:
- busca_linear (.each)
- busca_linear_index (.each_with_index)

Cenários testados:
- elemento no início
- elemento no meio
- elemento no fim
- elemento inexistente